### PR TITLE
Encase the paths used for mkdir in quotation marks

### DIFF
--- a/Install.bat
+++ b/Install.bat
@@ -6,7 +6,7 @@ set OUTPUT=%Documents%\maya\modules\zMayaTools.mod
 set INSTALL_DIR=%cd%
 
 rem Create the global modules directory if it doesn't exist.
-if not exist %Documents%\maya\modules mkdir %Documents%\maya\modules
+if not exist "%Documents%\maya\modules" mkdir "%Documents%\maya\modules"
 
 rem Create the .mod file in the user's Maya modules directory.
 echo + zMayaTools 1.0 %INSTALL_DIR% > "%OUTPUT%"


### PR DESCRIPTION
I ran into an issue with the installer where OneDrive had formatted the name of my OneDrive directory as "OneDrive - CompanyName". The - surrounded by spaces made the path evaluate as an argument when passed to mkdir and caused the script to fail.  Encasing the variables used by mkdir in quotation marks should ensure the whole path gets evaluated as a string. I made this simple change and it worked without problem.